### PR TITLE
add *colors to dwm configs

### DIFF
--- a/code/configs/dwm/arch-config.h
+++ b/code/configs/dwm/arch-config.h
@@ -22,6 +22,17 @@ static const unsigned int snap      = 32;       /* snap pixel */
 static const unsigned int gappx     = 0;
 static const Bool showbar           = False;     /* False means no bar */
 static const Bool topbar            = True;     /* False means bottom bar */
+static const char col_gray1[]       = "#222222";
+static const char col_gray2[]       = "#444444";
+static const char col_gray3[]       = "#bbbbbb";
+static const char col_gray4[]       = "#eeeeee";
+static const char col_cyan[]        = "#005577";
+static const char *colors[SchemeLast][3]      = {
+    /*               fg         bg         border   */
+    [SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
+    [SchemeSel] =  { col_gray4, col_cyan,  col_cyan  },
+};
+
 
 /* tagging */
 static const char *tags[] = { "1", "2", "3", "4", "5", "6", "7", "8", "9" };

--- a/code/configs/dwm/debian-config.h
+++ b/code/configs/dwm/debian-config.h
@@ -17,6 +17,16 @@ static const unsigned int snap      = 32;       /* snap pixel */
 static const unsigned int gappx     = 0;
 static const Bool showbar           = False;     /* False means no bar */
 static const Bool topbar            = True;     /* False means bottom bar */
+static const char col_gray1[]       = "#222222";
+static const char col_gray2[]       = "#444444";
+static const char col_gray3[]       = "#bbbbbb";
+static const char col_gray4[]       = "#eeeeee";
+static const char col_cyan[]        = "#005577";
+static const char *colors[SchemeLast][3]      = {
+    /*               fg         bg         border   */
+    [SchemeNorm] = { col_gray3, col_gray1, col_gray2 },
+    [SchemeSel] =  { col_gray4, col_cyan,  col_cyan  },
+};
 
 /* tagging */
 static const char *tags[] = { "1", "2", "3", "4", "5", "6", "7", "8", "9" };


### PR DESCRIPTION
config broke after dwm update, fixes:

```
root@archlinux:/home/vdloo/.dwm# make
dwm build options:
CFLAGS   = -std=c99 -pedantic -Wall -Wno-deprecated-declarations -Os -I/usr/X11R6/include -I/usr/include/freetype2 -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_C_SOURCE=2 -DVERSION="6.1" -DXINERAMA
LDFLAGS  = -s -L/usr/X11R6/lib -lX11 -lXinerama -lfontconfig -lXft
CC       = cc
CC dwm.c
dwm.c: In function ‘setup’:
dwm.c:1586:43: error: ‘colors’ undeclared (first use in this function)
  scheme[SchemeNorm] = drw_scm_create(drw, colors[SchemeNorm], 3);
                                           ^
dwm.c:1586:43: note: each undeclared identifier is reported only once for each function it appears in
Makefile:18: recipe for target 'dwm.o' failed
make: *** [dwm.o] Error 1
```

see the new config.def.h
